### PR TITLE
return Shortcut instance from make_shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,17 +8,17 @@ Pyshortcuts helps developers and Python users create desktop shortcuts that will
 
 Pyshortcuts is cross-platform, supporting Windows, MacOS, and Linux each in the way that
 is most natural for each OS. On Windows, a Shortcut or Link is created. On MacOS, a minimal
-but complete Application is created. On Linux a ".desktop" file is created. In all cases, 
-the shortcut can be put either directly on the Desktop of the current user or in a folder on 
+but complete Application is created. On Linux a ".desktop" file is created. In all cases,
+the shortcut can be put either directly on the Desktop of the current user or in a folder on
 the users Desktop. This means there is no need for elevated permission and no writing to
-system-level files (registry, /Applications, /usr/bin).  It also means there is no attempt to 
+system-level files (registry, /Applications, /usr/bin).  It also means there is no attempt to
 place in system-specific places like "Start Menu" or "Dock".  After the shortcut has been created,
 the user has complete control to rename, move, or delete it.  Shortcuts can have a custom
 icon (`.ico` files on Windows or Linux, or `.icns` files on MacOS) specified, defaulting to
 a Python icon included with pyshortcuts.
 
 Pyshortcuts is pure python, has a small footprint, is easy to install, and is easy to use
-from a python script.  This means that Pyshortcuts can easily be part of a installation 
+from a python script.  This means that Pyshortcuts can easily be part of a installation
 (or post-installation process) process for larger packages.
 
 ## installation
@@ -35,7 +35,7 @@ or
 conda install -c gsecars pyshortcuts
 ```
 
-On Windows, pyshortcuts requires the pywin32 package. This should be installed automatically 
+On Windows, pyshortcuts requires the pywin32 package. This should be installed automatically
 with either of the above install methods.
 
 In order to use the pyshortcut GUI, the wxPython package is required.
@@ -88,7 +88,7 @@ The `pyshortcut` command line program has the following optional arguments:
   * `-g`, `--gui`      run script as a GUI, with no Terminal Window [False]
   * `-w`, `--wxgui`    run GUI version of pyshortcut
 
-Note that running in the Terminal is True by default.  For GUI applications and extra Terminal or 
+Note that running in the Terminal is True by default.  For GUI applications and extra Terminal or
 Command Window may be unwanted, and can be disabled with the `-g` or `--gui` option.
 
 
@@ -106,9 +106,9 @@ This can be launched from the command line with
 ~> pyshortcut --wxgui
 ```
 
-Of course, that miht be the sort of command you might want to be able to launch by clicking
-on a desktop shortcut.  We have just the tool for that. This script (included as 
-`gui_bootstrap.py` in the `examples` folder) will create a dekstop shortcut that launches 
+Of course, that might be the sort of command you might want to be able to launch by clicking
+on a desktop shortcut.  We have just the tool for that. This script (included as
+`gui_bootstrap.py` in the `examples` folder) will create a desktop shortcut that launches
 the pyshortcut GUI:
 
 ```python
@@ -121,6 +121,10 @@ bindir = 'bin'
 if platform.startswith('win'):
     bindir = 'Scripts'
 
-make_shortcut("%s --wxgui" % os.path.join(sys.prefix, bindir, 'pyshortcut'),
-              name='PyShortcut', terminal=False)
+scut = make_shortcut(
+    "%s --wxgui" % os.path.join(sys.prefix, bindir, 'pyshortcut'),
+    name='PyShortcut', terminal=False
+)
+
+print("pyshortcuts GUI: %s" % scut.target)
 ```

--- a/examples/gui_bootstrap.py
+++ b/examples/gui_bootstrap.py
@@ -7,5 +7,8 @@ bindir = 'bin'
 if platform.startswith('win'):
     bindir = 'Scripts'
 
-make_shortcut("%s --wxgui" % os.path.join(sys.prefix, bindir, 'pyshortcut'),
-              name='PyShortcut', terminal=False)
+scut = make_shortcut(
+    "%s --wxgui" % os.path.join(sys.prefix, bindir, 'pyshortcut'),
+    name='PyShortcut', terminal=False)
+
+print("pyshortcuts GUI: %s" % scut.target)

--- a/pyshortcuts/__init__.py
+++ b/pyshortcuts/__init__.py
@@ -69,6 +69,7 @@ def shortcut_cli():
 
     desc = scriptname = args[0]
     print('creating %s shortcut for script %s' % (platform, scriptname))
-    make_shortcut(scriptname, name=options.name, description=desc,
-                  terminal=options.terminal, folder=options.folder,
-                  icon=options.icon)
+    scut = make_shortcut(scriptname, name=options.name, description=desc,
+                         terminal=options.terminal, folder=options.folder,
+                         icon=options.icon)
+    return scut

--- a/pyshortcuts/darwin.py
+++ b/pyshortcuts/darwin.py
@@ -108,3 +108,5 @@ end tell
     os.chmod(ascript_name, 493) ## = octal 755 / rwxr-xr-x
     icon_dest = os.path.join(dest, 'Contents', 'Resources', scut.name + '.icns')
     shutil.copy(scut.icon, icon_dest)
+
+    return scut

--- a/pyshortcuts/linux.py
+++ b/pyshortcuts/linux.py
@@ -42,4 +42,4 @@ Exec={exe:s} {script:s} {args:s}
            icon=scut.icon, script=scut.full_script, args=scut.args,
            term=term))
 
-
+    return scut

--- a/pyshortcuts/windows.py
+++ b/pyshortcuts/windows.py
@@ -49,3 +49,5 @@ def make_shortcut(script, name=None, description=None, terminal=True,
     wscript.Description = scut.description
     wscript.IconLocation = scut.icon
     wscript.save()
+
+    return scut

--- a/tests/test_pyshortcuts.py
+++ b/tests/test_pyshortcuts.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 import os
-from pyshortcuts import make_shortcut, platform
+from pyshortcuts import make_shortcut, platform, shortcut
 
 def test_shortcut():
     script = os.path.join('..', 'examples', 'console_scripts', 'timer.py') + ' -u 0.25 -t 10'
@@ -11,7 +11,8 @@ def test_shortcut():
         iext = 'icns'
 
     icon = "%s.%s" % (icon, iext)
-    make_shortcut(script, name='Timer', icon=icon)
+    scut = make_shortcut(script, name='Timer', icon=icon)
+    assert isinstance(scut, shortcut.Shortcut), 'it returns a shortcut instance'
 
 if __name__ == '__main__':
     test_shortcut()


### PR DESCRIPTION
For #2.

Thanks for this project!

This returns the `Shortcut` instance from the various `make_shortcut`s as well as `shortcut_cli`.

The test is updated to assert the return type.

The docs are updated to show an example of accessing the (for me) most important property of the (now public) Shortcut class, the target.