### PR TITLE
handle script param is already an .exe (#7)

### DIFF
--- a/pyshortcuts/windows.py
+++ b/pyshortcuts/windows.py
@@ -41,6 +41,10 @@ def make_shortcut(script, name=None, description=None, terminal=True,
             pyexe = tname
             scut.full_script = ''
 
+    if os.path.splitext(scut.full_script)[1].lower() == '.exe':
+        pyexe = scut.full_script
+        scut.full_script = ''
+
     wscript = Dispatch('WScript.Shell').CreateShortCut(scut.target)
     wscript.Targetpath = '"%s"' % pyexe
     wscript.Arguments = '%s %s' % (scut.full_script, scut.args)

--- a/pyshortcuts/windows.py
+++ b/pyshortcuts/windows.py
@@ -9,6 +9,12 @@ import sys
 from .utils import get_homedir
 from .shortcut import Shortcut
 
+
+def get_exe_types():
+    '''Return list of valid executable file extensions [.com, .exe, ...]'''
+    exetypes = [ext.lower() for ext in os.environ['PATHEXT'].split(os.pathsep)]
+    return exetypes
+
 def make_shortcut(script, name=None, description=None, terminal=True,
                   folder=None, icon=None):
     """create windows shortcut
@@ -33,15 +39,17 @@ def make_shortcut(script, name=None, description=None, terminal=True,
     if terminal:
         pyexe = os.path.join(sys.prefix, 'python.exe')
 
-    # check for other valid ways to run each script, allowing
-    # for Python's automagic creation of Windows exes.
+    # Check for other valid ways to run the script
+    # try appending .exe if script itself not found
     if not os.path.exists(scut.full_script):
         tname = scut.full_script + '.exe'
         if os.path.exists(tname):
             pyexe = tname
             scut.full_script = ''
 
-    if os.path.splitext(scut.full_script)[1].lower() == '.exe':
+    # If script is already executable use it directly instead of via pyexe
+    ext = os.path.splitext(scut.full_script)[1].lower()
+    if  ext in get_exe_types():
         pyexe = scut.full_script
         scut.full_script = ''
 


### PR DESCRIPTION
works on win10x64, py3.6. I don't know how to create a unit test for this. 

There's a pre-existing bug in line 50, `wscript.Arguments = '%s %s' % (scut.full_script, scut.args)` will create a shortcut target with empty whitespace suffix if the args are empty. Windows doesn't seem to care though so I didn't change it.