### PR TITLE
Work towards Menu as well as Desktop links

### DIFF
--- a/pyshortcuts/__init__.py
+++ b/pyshortcuts/__init__.py
@@ -10,7 +10,7 @@ from .utils import platform
 
 make_shortcut = None
 if platform.startswith('win'):
-    from .windows import make_shortcut
+    from .windows import make_shortcut, get_folders
 
 elif platform.startswith('darwin'):
     from .darwin import make_shortcut

--- a/pyshortcuts/__init__.py
+++ b/pyshortcuts/__init__.py
@@ -16,7 +16,7 @@ elif platform.startswith('darwin'):
     from .darwin import make_shortcut
 
 elif platform.startswith('linux'):
-    from .linux import make_shortcut
+    from .linux import make_shortcut, get_folders
 
 try:
     import wx

--- a/pyshortcuts/shortcut.py
+++ b/pyshortcuts/shortcut.py
@@ -85,21 +85,6 @@ class Shortcut():
         desktop = dest = folder
         print(f'---target dest: {dest}')
 
-        if platform == 'linux':
-            # search for .config/user-dirs.dirs in HOMEDIR
-            ud_file = os.path.join(homedir, '.config', 'user-dirs.dirs')
-            if os.path.exists(ud_file):
-                val = desktop
-                with open(ud_file, 'r') as fh:
-                    text = fh.readlines()
-                for line in text:
-                    if 'DESKTOP' in line:
-                        line = line.replace('$HOME', homedir)[:-1]
-                        key, val = line.split('=')
-                        val = val.replace('"', '').replace("'", "")
-                desktop = dest = val
-
-
         if not os.path.exists(dest):
             os.mkdir(dest)
 

--- a/pyshortcuts/shortcut.py
+++ b/pyshortcuts/shortcut.py
@@ -83,7 +83,7 @@ class Shortcut():
 
         #ignore all above, just make dest same as folder:
         desktop = dest = folder
-        print(f'---target dest: {dest}')
+        # print(f'---target dest: {dest}') # debug, py36+
 
         if not os.path.exists(dest):
             os.mkdir(dest)

--- a/pyshortcuts/shortcut.py
+++ b/pyshortcuts/shortcut.py
@@ -70,12 +70,20 @@ class Shortcut():
         if self.description is None:
             self.description = name
 
-        desktop = dest = os.path.join(get_homedir(), 'Desktop')
-        if folder is not None:
-            if folder.startswith(desktop):
-                folder = folder[len(desktop)+1:]
-            dest = os.path.join(desktop, folder)
+        # desktop = dest = os.path.join(get_homedir(), 'Desktop')
+        # if folder is not None:
+        #     # if folder var has a value
+        #     #   and it matches the beginning of just created `desktop` var
+        #     #   reassign folder var to be substring of folder var
+        #     #   that is 1 char longer that desktop var
+        #     # reassign `dest` to be desktop path + folder path
+        #     if folder.startswith(desktop):
+        #         folder = folder[len(desktop)+1:]
+        #     dest = os.path.join(desktop, folder)
 
+        #ignore all above, just make dest same as folder:
+        desktop = dest = folder
+        print(f'---target dest: {dest}')
 
         if not os.path.exists(dest):
             os.mkdir(dest)

--- a/pyshortcuts/utils.py
+++ b/pyshortcuts/utils.py
@@ -64,6 +64,17 @@ def get_win_folders():
 def get_homedir():
     "determine home directory of current user"
     home = None
+
+    def get_home_from_env():
+    # '~' -- should work on most Unixes
+    # then try common environmental variables
+        for var in ('~', '$HOME', '$HOMEPATH', '$USERPROFILE', '$ALLUSERSPROFILE'):
+            p = os.path.expandvars(var)
+            if os.path.exists(p):
+                return p
+
+    ## Verifies string coming out of expandvar doesn't match the var name
+    ## so doesn't provide much protection, the dir could still not exist
     # def check(method, s):
     #     "check that os.path.expanduser / expandvars gives a useful result"
     #     try:
@@ -78,36 +89,13 @@ def get_homedir():
     if HAS_PWD and susername is not None and home is None:
         home = pwd.getpwnam(susername).pw_dir
 
-    # try expanding '~' -- should work on most Unixes
-    if home is None:
-        # home = check(os.path.expanduser, '~')
-        p = os.path.expandvars('~')
-        if os.path.exists(p):
-            home = p
-
-    # try the common environmental variables
-    if home is None:
-        for var in ('$HOME', '$HOMEPATH', '$USERPROFILE', '$ALLUSERSPROFILE'):
-            p = os.path.expandvars(var)
-            if os.path.exists(p):
-                home = p
-                break
-            #home = check(os.path.expandvars, var)
-            #if home is not None:
-            #    break
-
-    ## USERPROFILE always exists (right?) so this next bit unneeded
-    # # For Windows, ask for parent of Roaming 'Application Data' directory
-    # if home is None and os.name == 'nt':
-    #     try:
-    #         from win32com.shell import shellcon, shell
-    #         home = shell.SHGetFolderPath(0, shellcon.CSIDL_APPDATA, 0, 0)
-    #     except ImportError:
-    #         pass
+    elif home is None:
+        home = get_home_from_env()
 
     # finally, use current folder
-    if home is None:
+    else:
         home = os.path.abspath('.')
+
     return nativepath(home)
 
 

--- a/pyshortcuts/utils.py
+++ b/pyshortcuts/utils.py
@@ -93,13 +93,14 @@ def get_homedir():
             #if home is not None:
             #    break
 
-    # For Windows, ask for parent of Roaming 'Application Data' directory
-    if home is None and os.name == 'nt':
-        try:
-            from win32com.shell import shellcon, shell
-            home = shell.SHGetFolderPath(0, shellcon.CSIDL_APPDATA, 0, 0)
-        except ImportError:
-            pass
+    ## USERPROFILE always exists (right?) so this next bit unneeded
+    # # For Windows, ask for parent of Roaming 'Application Data' directory
+    # if home is None and os.name == 'nt':
+    #     try:
+    #         from win32com.shell import shellcon, shell
+    #         home = shell.SHGetFolderPath(0, shellcon.CSIDL_APPDATA, 0, 0)
+    #     except ImportError:
+    #         pass
 
     # finally, use current folder
     if home is None:

--- a/pyshortcuts/utils.py
+++ b/pyshortcuts/utils.py
@@ -7,6 +7,7 @@ utilities for pyshortcuts
 """
 import os
 import sys
+from collections import namedtuple
 
 
 platform = sys.platform
@@ -39,7 +40,23 @@ try:
 except ImportError:
     HAS_PWD = False
 
-## mhw: WIP: getting a handle on named tuples
+## WIP: unix folder paths
+def get_nix_folders():
+    """Return named tuple of Home, Desktop and StartMenu paths.
+
+        folders = get_nix_folders()
+        print("Home, Desktop, StartMenu ",
+            folders.home, folders.desktop, folders.startmenu)
+    """
+    nt = namedtuple("folders", "home desktop startmenu")
+    folders = nt(get_homedir(),
+                os.path.join(get_homedir(), "Desktop"),
+                None)
+    return folders
+
+##
+
+
 def get_win_folders():
     """Return named tuple of Home, Desktop and Startmenu paths.
 
@@ -50,7 +67,6 @@ def get_win_folders():
     import win32com.client
 
     shellapp = win32com.client.Dispatch("Shell.Application")
-    from collections import namedtuple
 
     nt = namedtuple("folders", "home desktop startmenu")
     folders = nt(
@@ -66,8 +82,6 @@ def get_win_folders():
     # Start menu: user = 11, all users = 22
     # Desktop   : user =  0, all users = 25
     # Profile   : = 40, same as %USERPROFILE%
-
-##
 
 
 def get_homedir():

--- a/pyshortcuts/utils.py
+++ b/pyshortcuts/utils.py
@@ -80,7 +80,10 @@ def get_homedir():
 
     # try expanding '~' -- should work on most Unixes
     if home is None:
-        home = check(os.path.expanduser, '~')
+        # home = check(os.path.expanduser, '~')
+        p = os.path.expandvars('~')
+        if os.path.exists(p):
+            home = p
 
     # try the common environmental variables
     if home is None:

--- a/pyshortcuts/utils.py
+++ b/pyshortcuts/utils.py
@@ -36,11 +36,6 @@ try:
 except ImportError:
     HAS_PWD = False
 
-
-#folders = get_folders()
-#if folders:
-#    print("Home, Desktop, StartMenu ", folders.home, folders.desktop, folders.start_menu)
-
 ## mhw: WIP: getting a handle on named tuples
 def get_win_folders():
     '''Return named tuple of Home, Desktop and Startmenu paths.
@@ -57,28 +52,26 @@ def get_win_folders():
                 shellapp.namespace(11).self.path,
                 shellapp.namespace(0).self.path)
     return folders
-
-# Windows Special Folders
-# ID numbers from https://gist.github.com/maphew/47e67b6a99e240f01aced8b6b5678eeb
-# https://docs.microsoft.com/en-gb/windows/win32/api/shldisp/ne-shldisp-shellspecialfolderconstants#constants
-#
-# Start menu: user = 11, all users = 22
-# Desktop   : user =  0, all users = 25
-
+    # Windows Special Folders
+    # ID numbers from https://gist.github.com/maphew/47e67b6a99e240f01aced8b6b5678eeb
+    # https://docs.microsoft.com/en-gb/windows/win32/api/shldisp/ne-shldisp-shellspecialfolderconstants#constants
+    #
+    # Start menu: user = 11, all users = 22
+    # Desktop   : user =  0, all users = 25
 
 ##
 
 def get_homedir():
     "determine home directory of current user"
     home = None
-    def check(method, s):
-        "check that os.path.expanduser / expandvars gives a useful result"
-        try:
-            if method(s) not in (None, s):
-                return method(s)
-        except:
-            pass
-        return None
+    # def check(method, s):
+    #     "check that os.path.expanduser / expandvars gives a useful result"
+    #     try:
+    #         if method(s) not in (None, s):
+    #             return method(s)
+    #     except:
+    #         pass
+    #     return None
 
     # for Unixes, allow for sudo case
     susername = os.environ.get("SUDO_USER", None)
@@ -90,11 +83,15 @@ def get_homedir():
         home = check(os.path.expanduser, '~')
 
     # try the common environmental variables
-    if home is  None:
+    if home is None:
         for var in ('$HOME', '$HOMEPATH', '$USERPROFILE', '$ALLUSERSPROFILE'):
-            home = check(os.path.expandvars, var)
-            if home is not None:
+            p = os.path.expandvars(var)
+            if os.path.exists(p):
+                home = p
                 break
+            #home = check(os.path.expandvars, var)
+            #if home is not None:
+            #    break
 
     # For Windows, ask for parent of Roaming 'Application Data' directory
     if home is None and os.name == 'nt':

--- a/pyshortcuts/utils.py
+++ b/pyshortcuts/utils.py
@@ -41,23 +41,32 @@ except ImportError:
 #if folders:
 #    print("Home, Desktop, StartMenu ", folders.home, folders.desktop, folders.start_menu)
 
-# mhw: WIP: getting a handle on named tuples
+## mhw: WIP: getting a handle on named tuples
 def get_win_folders():
-    from collections import namedtuple
-    nt = namedtuple('folders', 'name path')
-    folders = nt('Home', os.environ('USERPROFILE'))
-    folders = nt('Desktop', 'result from get_desktop_win()')
-    folders = nt('Menu', 'result from get_startmenu_win()')
-    return folders
-    # only the last is returned; not what we want.
-    # how to add and keep many table rows?
-    # oh, we need to keep list. I'm not sure thiss is what I want:
-    #   all_results = []
-    #     for result in results:
-    #     result = SomeRowResult(table1.col1, table2.col1, table3.col1)
-    #     all_results.append(result)
-    # https://stackoverflow.com/a/20096972/14420
+    '''Return named tuple of Home, Desktop and Startmenu paths.
 
+        folders = get_win_folders()
+        print("Home, Desktop, StartMenu ",
+            folders.home, folders.desktop, folders.startmenu)
+    '''
+    import win32com.client
+    shellapp = win32com.client.Dispatch("Shell.Application")
+    from collections import namedtuple
+    nt = namedtuple('folders', 'home desktop startmenu')
+    folders = nt(os.environ['USERPROFILE'],
+                shellapp.namespace(11).self.path,
+                shellapp.namespace(0).self.path)
+    return folders
+
+# Windows Special Folders
+# ID numbers from https://gist.github.com/maphew/47e67b6a99e240f01aced8b6b5678eeb
+# https://docs.microsoft.com/en-gb/windows/win32/api/shldisp/ne-shldisp-shellspecialfolderconstants#constants
+#
+# Start menu: user = 11, all users = 22
+# Desktop   : user =  0, all users = 25
+
+
+##
 
 def get_homedir():
     "determine home directory of current user"

--- a/pyshortcuts/utils.py
+++ b/pyshortcuts/utils.py
@@ -54,7 +54,7 @@ def get_win_folders():
 
     nt = namedtuple("folders", "home desktop startmenu")
     folders = nt(
-        os.environ["USERPROFILE"],
+        shellapp.namespace(40).self.path,
         shellapp.namespace(11).self.path,
         shellapp.namespace(0).self.path,
     )
@@ -65,7 +65,7 @@ def get_win_folders():
     #
     # Start menu: user = 11, all users = 22
     # Desktop   : user =  0, all users = 25
-
+    # Profile   : = 40, same as %USERPROFILE%
 
 ##
 

--- a/pyshortcuts/utils.py
+++ b/pyshortcuts/utils.py
@@ -1,33 +1,36 @@
 #!/usr/bin/env python
 """
 utilities for pyshortcuts
-  get_homedir()  get home directory
-  get_paths()
-
+  get_homedir()         get home directory (all platforms)
+  get_win_folders()     get Home, Desktop and Startmenu paths
+  fix_paths()           get absolute paths for script, target folder, icon
 """
 import os
 import sys
 
 
 platform = sys.platform
-if os.name == 'nt':
-    platform = 'win'
-if platform == 'linux2':
-    platform = 'linux'
+if os.name == "nt":
+    platform = "win"
+if platform == "linux2":
+    platform = "linux"
+
 
 def unixpath(d):
     "unix path"
-    return d.replace('\\', '/')
+    return d.replace("\\", "/")
+
 
 def winpath(d):
     "ensure path uses windows delimiters"
-    if d.startswith('//'):
+    if d.startswith("//"):
         d = d[1:]
-    d = d.replace('/', '\\')
+    d = d.replace("/", "\\")
     return d
 
+
 nativepath = unixpath
-if platform == 'win':
+if platform == "win":
     nativepath = winpath
 
 HAS_PWD = True
@@ -38,19 +41,23 @@ except ImportError:
 
 ## mhw: WIP: getting a handle on named tuples
 def get_win_folders():
-    '''Return named tuple of Home, Desktop and Startmenu paths.
+    """Return named tuple of Home, Desktop and Startmenu paths.
 
         folders = get_win_folders()
         print("Home, Desktop, StartMenu ",
             folders.home, folders.desktop, folders.startmenu)
-    '''
+    """
     import win32com.client
+
     shellapp = win32com.client.Dispatch("Shell.Application")
     from collections import namedtuple
-    nt = namedtuple('folders', 'home desktop startmenu')
-    folders = nt(os.environ['USERPROFILE'],
-                shellapp.namespace(11).self.path,
-                shellapp.namespace(0).self.path)
+
+    nt = namedtuple("folders", "home desktop startmenu")
+    folders = nt(
+        os.environ["USERPROFILE"],
+        shellapp.namespace(11).self.path,
+        shellapp.namespace(0).self.path,
+    )
     return folders
     # Windows Special Folders
     # ID numbers from https://gist.github.com/maphew/47e67b6a99e240f01aced8b6b5678eeb
@@ -59,30 +66,20 @@ def get_win_folders():
     # Start menu: user = 11, all users = 22
     # Desktop   : user =  0, all users = 25
 
+
 ##
+
 
 def get_homedir():
     "determine home directory of current user"
     home = None
 
     def get_home_from_env():
-    # '~' -- should work on most Unixes
-    # then try common environmental variables
-        for var in ('~', '$HOME', '$HOMEPATH', '$USERPROFILE', '$ALLUSERSPROFILE'):
+        # try '~' which works on most Unixes, then common environmental variables
+        for var in ("~", "$HOME", "$HOMEPATH", "$USERPROFILE", "$ALLUSERSPROFILE"):
             p = os.path.expandvars(var)
             if os.path.exists(p):
                 return p
-
-    ## Verifies string coming out of expandvar doesn't match the var name
-    ## so doesn't provide much protection, the dir could still not exist
-    # def check(method, s):
-    #     "check that os.path.expanduser / expandvars gives a useful result"
-    #     try:
-    #         if method(s) not in (None, s):
-    #             return method(s)
-    #     except:
-    #         pass
-    #     return None
 
     # for Unixes, allow for sudo case
     susername = os.environ.get("SUDO_USER", None)
@@ -94,7 +91,7 @@ def get_homedir():
 
     # finally, use current folder
     else:
-        home = os.path.abspath('.')
+        home = os.path.abspath(".")
 
     return nativepath(home)
 
@@ -109,7 +106,7 @@ def fix_paths(script, folder=None, icon_path=None, icon=None):
     """
     scriptname = os.path.abspath(script)
 
-    dest = os.path.join(get_homedir(), 'Desktop')
+    dest = os.path.join(get_homedir(), "Desktop")
     if folder is not None:
         dest = os.path.join(dest, folder)
         if not os.path.exists(dest):
@@ -117,12 +114,12 @@ def fix_paths(script, folder=None, icon_path=None, icon=None):
 
     if icon_path is None:
         _path, _fname = os.path.split(__file__)
-        icon_path = os.path.join(_path, 'icons')
+        icon_path = os.path.join(_path, "icons")
     if icon is None:
-        icon = 'py'
-    ext = '.ico'
-    if platform.startswith('darwin'):
-        ext = '.icns'
+        icon = "py"
+    ext = ".ico"
+    if platform.startswith("darwin"):
+        ext = ".icns"
     iconfile = os.path.abspath(os.path.join(icon_path, icon + ext))
 
     return scriptname, dest, iconfile

--- a/pyshortcuts/utils.py
+++ b/pyshortcuts/utils.py
@@ -36,6 +36,29 @@ try:
 except ImportError:
     HAS_PWD = False
 
+
+#folders = get_folders()
+#if folders:
+#    print("Home, Desktop, StartMenu ", folders.home, folders.desktop, folders.start_menu)
+
+# mhw: WIP: getting a handle on named tuples
+def get_win_folders():
+    from collections import namedtuple
+    nt = namedtuple('folders', 'name path')
+    folders = nt('Home', os.environ('USERPROFILE'))
+    folders = nt('Desktop', 'result from get_desktop_win()')
+    folders = nt('Menu', 'result from get_startmenu_win()')
+    return folders
+    # only the last is returned; not what we want.
+    # how to add and keep many table rows?
+    # oh, we need to keep list. I'm not sure thiss is what I want:
+    #   all_results = []
+    #     for result in results:
+    #     result = SomeRowResult(table1.col1, table2.col1, table3.col1)
+    #     all_results.append(result)
+    # https://stackoverflow.com/a/20096972/14420
+
+
 def get_homedir():
     "determine home directory of current user"
     home = None

--- a/pyshortcuts/windows.py
+++ b/pyshortcuts/windows.py
@@ -34,6 +34,32 @@ def get_desktop_folder():
     return shellapp.namespace(0).self.path
 
 
+def get_folders():
+    """Return named tuple of Home, Desktop and Startmenu paths.
+
+        folders = get_win_folders()
+        print("Home, Desktop, StartMenu ",
+            folders.home, folders.desktop, folders.startmenu)
+    """
+    import win32com.client
+    from collections import namedtuple
+
+    shellapp = win32com.client.Dispatch("Shell.Application")
+
+    nt = namedtuple("folders", "home desktop startmenu")
+    folders = nt(
+        shellapp.namespace(40).self.path,
+        shellapp.namespace(0).self.path,
+        shellapp.namespace(11).self.path,
+    )
+    return folders
+    # Windows Special Folders
+    # ID numbers from https://gist.github.com/maphew/47e67b6a99e240f01aced8b6b5678eeb
+    # https://docs.microsoft.com/en-gb/windows/win32/api/shldisp/ne-shldisp-shellspecialfolderconstants#constants
+    #
+    # Start menu: user = 11, all users = 22
+    # Desktop   : user =  0, all users = 25
+    # Profile   : = 40, same as %USERPROFILE%
 def make_shortcut(script, name=None, description=None, terminal=True,
                   folder=None, icon=None):
     """create windows shortcut
@@ -47,11 +73,11 @@ def make_shortcut(script, name=None, description=None, terminal=True,
     folder      (str or None) folder on Desktop to put shortcut [defaults to Desktop]
     terminal    (True or False) whether to run in a Terminal  [True]
     """
+    homedir = get_homedir()
+    print(f'--- windows.py:make_shortcut() folder= {folder}')
 
     scut = Shortcut(script, name=name, description=description,
                     folder=folder, icon=icon)
-
-    homedir = get_homedir()
 
     pyexe = os.path.join(sys.prefix, 'pythonw.exe')
     if terminal:

--- a/pyshortcuts/windows.py
+++ b/pyshortcuts/windows.py
@@ -22,6 +22,10 @@ def get_exe_types():
 # Windows Special Folders
 # ID numbers from https://gist.github.com/maphew/47e67b6a99e240f01aced8b6b5678eeb
 # https://docs.microsoft.com/en-gb/windows/win32/api/shldisp/ne-shldisp-shellspecialfolderconstants#constants
+#
+# Start menu: user = 11, all users = 22
+# Desktop   : user =  0, all users = 25
+#
 def get_menu_folder():
     '''Return user Start Menu folder'''
     return shellapp.namespace(11).self.path

--- a/pyshortcuts/windows.py
+++ b/pyshortcuts/windows.py
@@ -74,7 +74,7 @@ def make_shortcut(script, name=None, description=None, terminal=True,
     terminal    (True or False) whether to run in a Terminal  [True]
     """
     homedir = get_homedir()
-    print(f'--- windows.py:make_shortcut() folder= {folder}')
+    # print(f'--- windows.py:make_shortcut() folder= {folder}') # debug, py36+
 
     scut = Shortcut(script, name=name, description=description,
                     folder=folder, icon=icon)

--- a/tests/test_pyshortcuts.py
+++ b/tests/test_pyshortcuts.py
@@ -21,7 +21,7 @@ def test_shortcut():
     scut = make_shortcut(script, name='Timer', icon=icon, folder=folders.desktop)
     assert isinstance(scut, shortcut.Shortcut), 'it returns a shortcut instance'
 
-    raise err # force crash so we see manual print() debug statements
+    #raise err # force crash so we see manual print() debug statements
 
 if __name__ == '__main__':
     test_shortcut()

--- a/tests/test_pyshortcuts.py
+++ b/tests/test_pyshortcuts.py
@@ -1,11 +1,15 @@
 #!/usr/bin/env python
 import os
-from pyshortcuts import make_shortcut, platform, shortcut
+from pyshortcuts import make_shortcut, platform, shortcut, get_folders
 
 root = os.path.abspath(os.path.join(__file__, '..', '..'))
 
+folders = get_folders()
 
 def test_shortcut():
+    print("---folders:\n Home: {}\n Desktop: {}\n StartMenu: {}\n".format(
+        folders.home, folders.desktop, folders.startmenu))
+
     script = os.path.join(root, 'examples', 'console_scripts', 'timer.py') + ' -u 0.25 -t 10'
     icon  = os.path.join(root, 'examples', 'icons', 'stopwatch')
 
@@ -14,8 +18,11 @@ def test_shortcut():
         iext = 'icns'
 
     icon = "%s.%s" % (icon, iext)
-    scut = make_shortcut(script, name='Timer', icon=icon)
+    scut = make_shortcut(script, name='Timer', icon=icon, folder=folders.desktop)
     assert isinstance(scut, shortcut.Shortcut), 'it returns a shortcut instance'
+
+    raise err # force crash so we see manual print() debug statements
 
 if __name__ == '__main__':
     test_shortcut()
+


### PR DESCRIPTION
_Nutshell: I prefer Menu links over Desktop links as too many icons on the desktop distract me. So the `menu-links` branch is about adding the option of creating these._ 

This isn't ready to merge. It's okay if it were merged as it doesn't hurt or change any existing behaviour. I created the PR because it's the easiest way I know to see the differences and talk about where I'm aiming.

New things: `get_menu_folder()` and `get_desktop_folder()` are succinct means to get the full path to these folders on Windows regardless of locale (language), Windows version,and  [user moved Desktop somewhere else](https://winaero.com/blog/move-desktop-folder-windows-10/).
```
import win32com.client
shellapp = win32com.client.Dispatch("Shell.Application")
def get_menu_folder():
    '''Return user Start Menu folder'''
    return shellapp.namespace(11).self.path
def get_desktop_folder():
    '''Return user Desktop folder'''
    return shellapp.namespace(0).self.path
```
I put them in `windows.py` because they don't apply to any other OS. However logistically I see how they might fit better in `utils.py`. In `get_homedir()` The windows code for home would be: 

    shellapp.namespace(40).self.path   # 40 = user profile dir (`C:\Users\Matt` in Win10)

Note: there's nothing wrong with current cross-platform method of querying environment vars to find HOME or USERPROFILE. Where this changes is extrapolating from Userprofile to Desktop and Start Menu as they're not guaranteed to be underneath in the same place.

Which brings us to **shortcut.py** and murky waters. I did start down this road, but backed out because it was quickly turning into a "rewrite half the file" scenario and I got nervous about the scale of change. I'm okay with functions, but my brain hasn't grokked Classes yet. Can you provide some suggestions of next steps?

