### PR TITLE
Handle (and test with) explicit path conda prefix

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ for:
         - USE_CONDA: base
     install:
       - "%CONDA_INSTALL_LOCN%\\Scripts\\conda.exe install -yn base %DEPS%"
-      - "%CONDA_INSTALL_LOCN%\\python.exe setup.py install --no-deps"
+      - "%CONDA_INSTALL_LOCN%\\Scripts\\activate.bat && python -m pip install . --no-deps"
     test_script:
       - "cd tests && call %CONDA_INSTALL_LOCN%\\Scripts\\activate.bat base && pytest"
 
@@ -35,6 +35,6 @@ for:
         - USE_CONDA: env
     install:
       - "%CONDA_INSTALL_LOCN%\\Scripts\\conda.exe create -yp c:\\test-env python=3.8 %DEPS%"
-      - "%CONDA_INSTALL_LOCN%\\Scripts\\activate.bat c:\\test-env && python setup.py install --no-deps"
+      - "%CONDA_INSTALL_LOCN%\\Scripts\\activate.bat c:\\test-env && python -m pip install . --no-deps"
     test_script:
       - "cd tests && call %CONDA_INSTALL_LOCN%\\Scripts\\activate.bat c:\\test-env && pytest"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,18 +1,45 @@
-
-environment:
-
-  matrix:
-
-     - PYTHON: "C:\\Python27-x64"
-     - PYTHON: "C:\\Python35-x64"
-     - PYTHON: "C:\\Python36-x64"
-
-install:
-    - "%PYTHON%\\python.exe -m pip install wheel pip six pywin32 pytest"
-    - "%PYTHON%\\python.exe setup.py install"
-
 build: off
 
-test_script:
-    - cd tests
-    - "%PYTHON%\\python.exe -m pytest"
+environment:
+  DEPS: wheel pip six pywin32 pytest
+  USE_CONDA: "0"
+  USE_CONDA_BASE: "0"
+  matrix:
+    - PYTHON: "C:\\Python27-x64"
+    - PYTHON: "C:\\Python35-x64"
+    - PYTHON: "C:\\Python36-x64"
+    - CONDA_INSTALL_LOCN: "C:\\Miniconda37-x64"
+      USE_CONDA: "1"
+      USE_CONDA_BASE: "1"
+    - CONDA_INSTALL_LOCN: "C:\\Miniconda37-x64"
+      USE_CONDA: "1"
+
+for:
+  - matrix:
+      only:
+        USE_CONDA: "0"
+    install:
+      - "%PYTHON%\\python.exe -m pip install %DEPS%"
+      - "%PYTHON%\\python.exe setup.py install"
+    test_script:
+      - "cd tests && %PYTHON%\\python.exe -m pytest"
+
+  - matrix:
+      only:
+        USE_CONDA: "1"
+        USE_CONDA_BASE: "1"
+    install:
+      - "%CONDA_INSTALL_LOCN%\\Scripts\\conda.exe install -yn base %DEPS%"
+      - "%CONDA_INSTALL_LOCN%\\python.exe setup.py install"
+    test_script:
+      - "cd tests && call %CONDA_INSTALL_LOCN%\\Scripts\\activate.bat base && pytest"
+
+  - matrix:
+      only:
+          USE_CONDA: "1"
+          USE_CONDA_BASE: "0"
+    install:
+      - "%CONDA_INSTALL_LOCN%\\Scripts\\conda.exe create -yp c:\\test-env python=3.8 %DEPS%"
+      - "%CONDA_INSTALL_LOCN%\\Scripts\\activate.bat c:\\test-env && python setup.py install"
+    test_script:
+      - "cd tests && call %CONDA_INSTALL_LOCN%\\Scripts\\activate.bat c:\\test-env && pytest"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ for:
         - USE_CONDA: base
     install:
       - "%CONDA_INSTALL_LOCN%\\Scripts\\conda.exe install -yn base %DEPS%"
-      - "%CONDA_INSTALL_LOCN%\\python.exe setup.py install"
+      - "%CONDA_INSTALL_LOCN%\\python.exe setup.py install --no-deps"
     test_script:
       - "cd tests && call %CONDA_INSTALL_LOCN%\\Scripts\\activate.bat base && pytest"
 
@@ -35,6 +35,6 @@ for:
         - USE_CONDA: env
     install:
       - "%CONDA_INSTALL_LOCN%\\Scripts\\conda.exe create -yp c:\\test-env python=3.8 %DEPS%"
-      - "%CONDA_INSTALL_LOCN%\\Scripts\\activate.bat c:\\test-env && python setup.py install"
+      - "%CONDA_INSTALL_LOCN%\\Scripts\\activate.bat c:\\test-env && python setup.py install --no-deps"
     test_script:
       - "cd tests && call %CONDA_INSTALL_LOCN%\\Scripts\\activate.bat c:\\test-env && pytest"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,22 +2,20 @@ build: off
 
 environment:
   DEPS: wheel pip six pywin32 pytest
-  USE_CONDA: "0"
-  USE_CONDA_BASE: "0"
+  USE_CONDA: disabled
   matrix:
     - PYTHON: "C:\\Python27-x64"
     - PYTHON: "C:\\Python35-x64"
     - PYTHON: "C:\\Python36-x64"
     - CONDA_INSTALL_LOCN: "C:\\Miniconda37-x64"
-      USE_CONDA: "1"
-      USE_CONDA_BASE: "1"
+      USE_CONDA: base
     - CONDA_INSTALL_LOCN: "C:\\Miniconda37-x64"
-      USE_CONDA: "1"
+      USE_CONDA: env
 
 for:
   - matrix:
       only:
-        - USE_CONDA: "0"
+        - USE_CONDA: disabled
     install:
       - "%PYTHON%\\python.exe -m pip install %DEPS%"
       - "%PYTHON%\\python.exe setup.py install"
@@ -26,8 +24,7 @@ for:
 
   - matrix:
       only:
-        - USE_CONDA: "1"
-          USE_CONDA_BASE: "1"
+        - USE_CONDA: base
     install:
       - "%CONDA_INSTALL_LOCN%\\Scripts\\conda.exe install -yn base %DEPS%"
       - "%CONDA_INSTALL_LOCN%\\python.exe setup.py install"
@@ -36,8 +33,7 @@ for:
 
   - matrix:
       only:
-        - USE_CONDA: "1"
-          USE_CONDA_BASE: "0"
+        - USE_CONDA: env
     install:
       - "%CONDA_INSTALL_LOCN%\\Scripts\\conda.exe create -yp c:\\test-env python=3.8 %DEPS%"
       - "%CONDA_INSTALL_LOCN%\\Scripts\\activate.bat c:\\test-env && python setup.py install"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,9 @@
 build: off
 
 environment:
-  DEPS: wheel pip six pywin32 pytest
-  USE_CONDA: disabled
+  global:
+    DEPS: wheel pip six pywin32 pytest
+    USE_CONDA: disabled
   matrix:
     - PYTHON: "C:\\Python27-x64"
     - PYTHON: "C:\\Python35-x64"
@@ -12,16 +13,14 @@ environment:
     - CONDA_INSTALL_LOCN: "C:\\Miniconda37-x64"
       USE_CONDA: env
 
-for:
-  - matrix:
-      only:
-        - USE_CONDA: disabled
-    install:
-      - "%PYTHON%\\python.exe -m pip install %DEPS%"
-      - "%PYTHON%\\python.exe setup.py install"
-    test_script:
-      - "cd tests && %PYTHON%\\python.exe -m pytest"
+install:
+  - "%PYTHON%\\python.exe -m pip install %DEPS%"
+  - "%PYTHON%\\python.exe setup.py install"
 
+test_script:
+  - "cd tests && %PYTHON%\\python.exe -m pytest"
+
+for:
   - matrix:
       only:
         - USE_CONDA: base

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ environment:
 for:
   - matrix:
       only:
-        USE_CONDA: "0"
+        - USE_CONDA: "0"
     install:
       - "%PYTHON%\\python.exe -m pip install %DEPS%"
       - "%PYTHON%\\python.exe setup.py install"
@@ -26,8 +26,8 @@ for:
 
   - matrix:
       only:
-        USE_CONDA: "1"
-        USE_CONDA_BASE: "1"
+        - USE_CONDA: "1"
+          USE_CONDA_BASE: "1"
     install:
       - "%CONDA_INSTALL_LOCN%\\Scripts\\conda.exe install -yn base %DEPS%"
       - "%CONDA_INSTALL_LOCN%\\python.exe setup.py install"
@@ -36,7 +36,7 @@ for:
 
   - matrix:
       only:
-          USE_CONDA: "1"
+        - USE_CONDA: "1"
           USE_CONDA_BASE: "0"
     install:
       - "%CONDA_INSTALL_LOCN%\\Scripts\\conda.exe create -yp c:\\test-env python=3.8 %DEPS%"

--- a/pyshortcuts/windows.py
+++ b/pyshortcuts/windows.py
@@ -20,11 +20,13 @@ ico_ext = 'ico'
 
 def get_conda_info():
     '''Return conda info, or None if not in an activated conda env'''
-    if not os.environ.get('CONDA_DEFAULT_ENV', '').strip():
+    conda_exe = os.environ.get('CONDA_EXE', None)
+
+    if not (conda_exe and os.path.exists(conda_exe)):
         return None
 
     return json.loads(
-        subprocess.check_output(['conda', 'info', '--json']).decode('utf-8')
+        subprocess.check_output([conda_exe, 'info', '--json']).decode('utf-8')
     )
 
 CONDA_INFO = get_conda_info()

--- a/pyshortcuts/windows.py
+++ b/pyshortcuts/windows.py
@@ -4,7 +4,6 @@ Create desktop shortcuts for Windows
 """
 from __future__ import print_function
 import os
-import re
 import sys
 import json
 import time

--- a/pyshortcuts/windows.py
+++ b/pyshortcuts/windows.py
@@ -19,12 +19,12 @@ scut_ext = 'lnk'
 ico_ext = 'ico'
 
 def get_conda_info():
-    '''Return conda info, or None if not in conda'''
-    if os.path.exists(os.path.join(sys.prefix, "conda-meta")):
+    '''Return conda info, or None if not in an activated conda env'''
+    if not os.environ.get('CONDA_DEFAULT_ENV', '').strip():
         return None
 
     return json.loads(
-        subprocess.check_output(["conda", "info", "--json"]).decode("utf-8")
+        subprocess.check_output(['conda', 'info', '--json']).decode('utf-8')
     )
 
 CONDA_INFO = get_conda_info()


### PR DESCRIPTION
Hello again! Thanks so much for pyshortcuts. We're looking forward to upgrading to the newest version on [robotlab](https://github.com/robots-from-jupyter/robotlab) and enjoying your hard-won windows hacking to get more predictable windows shortcuts.

As part of that, and trying to reduce my CI burden there, I was recently trying to put together a [conda-forge feedstock](https://github.com/conda-forge/staged-recipes/pull/11019), and since you kindly package the tests, I gave it a whirl: turns out, `conda-build` (and various other kinds of conda-y things, like `constructor`... thanks for the contributions over there!) can `activate c:\someplace\or\another` rather than the name in `c:\anaconda\envs` or whatever. This leads to hard-to-debug `bat` scripts, e.g. `c:\my-env\Scripts\envrunner-C:\my-env.bat`, as I've generally been creating shortcuts in the `constructor` `postbuild.bat`, which is notoriously hard to instrument under test.

This PR hopefully:
- fixes #25
- detects the presence of `conda.exe` off the `CONDA_EXE` env variable, which _always_ points at a **file** (rather than `CONDA_DEFAULT_ENV`, which just points at... something activateable)
  - uses that to shell out with `info --json` for the "canonical" information
- removes the dynamic portion of the env runner script name (since it will always be in the same place with the same name)
  - adds error catching and reporting, again for testability
  - uses the full host conda path (e.g. `c:\anaconda` or `c:\miniconda`... or `c:\robotlab`)`\Scripts\activate.bat` to activate, rather than relying on `%PATH%` having been updated during installation to feed `%dp`
- adds two appveyor excursions for conda
  - a `base` run (with py37)
  - a freshly-created py38 env

It still doesn't try to actually _execute_ the shortcuts, which is probably worth doing at some point, but hopefully will help squash the current issues, and help keep problems from cropping up in the future.

Thanks again!