### PR TITLE
Testing on Windows

### DIFF
--- a/pyshortcuts/windows.py
+++ b/pyshortcuts/windows.py
@@ -120,7 +120,7 @@ def make_shortcut(script, name=None, description=None, icon=None,
     # If script is already executable use it directly instead of via pyexe
     ext = os.path.splitext(scut.full_script)[1].lower()
     known_exes = [e.lower() for e in os.environ['PATHEXT'].split(os.pathsep)]
-    if ext in known_exes:
+    if ext != '.py' and ext in known_exes:
         executable = scut.full_script
         full_script = ''
     full_script = ' '.join((full_script, scut.arguments))

--- a/pyshortcuts/windows.py
+++ b/pyshortcuts/windows.py
@@ -107,7 +107,8 @@ def make_shortcut(script, name=None, description=None, icon=None,
     full_script = scut.full_script
     if executable is None:
         pyexe = 'python.exe' if terminal else 'pythonw.exe'
-        executable = os.path.normpath(os.path.join(sys.prefix, pyexe))
+        pydir = os.path.dirname(sys.executable)
+        executable = os.path.normpath(os.path.join(pydir, pyexe))
 
     # Check for other valid ways to run the script
     # try appending .exe if script itself not found


### PR DESCRIPTION
I am using pyshortcuts in my Python projects, and it works great.
On Linux everything works as expected, no issues.
But when I tested on Windows 10, I faced two issues, which I tried to fix by this PR:

1. In pyshortcuts/windows.py, make_shortcut uses "PATHEXT" environment variable (which holds known executable file extensions) to test if a script is a standalone executable. But in my specific case "PATHEXT" environment variable contained ".PY" which caused a problem: any Python file passed to make_shortcut was considered a standalone executable and was used without python.exe:

$Env:PATHEXT
.COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC;.PY;.PYW;.CPL

I am suggesting to fix this issue by adding condition ext != '.py' to the code in pyshortcuts/windows.py:

    if ext != '.py' and ext in known_exes:
        executable = scut.full_script

2. On Windows 10, if make_shortcut is called from a virtual environment (venv), correct Python binary location is path_to_venv\Scripts\
Using just sys.prefix gives incorrect Python binary location: path_to_venv\

I am suggesting to solve the issue by using os.path.dirname(sys.executable) to get Python binary location in pyshortcuts/windows.py:

    if executable is None:
        pyexe = 'python.exe' if terminal else 'pythonw.exe'
        pydir = os.path.dirname(sys.executable)
        executable = os.path.normpath(os.path.join(pydir, pyexe))

Best regards,
Dmitry