### PR TITLE
Remove use of python.app on macOS

### DIFF
--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -9,7 +9,7 @@ jobs:
       max-parallel: 5
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.8, 3.9, "3.10", 3.11]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python from Miniconda

--- a/.github/workflows/test-ubuntu.yml
+++ b/.github/workflows/test-ubuntu.yml
@@ -9,7 +9,7 @@ jobs:
       max-parallel: 5
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.8, 3.9, "3.10", "3.11"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python from Miniconda

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -10,7 +10,7 @@ jobs:
       max-parallel: 5
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.8, 3.9, "3.10", "3.11"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python from Miniconda

--- a/README.md
+++ b/README.md
@@ -27,9 +27,7 @@ of the Desktop / Start Menu.
 Special attention is given to Anaconda Python.  On Windows, this means the
 program linked to by the shortcut will be run in an Anaconda environment,
 explicitly selecting the "base" environment even if that has not been
-explicitly set.  On MacOS, the shortcut will make sure to use the
-`python.app` application so that GUI programs will be able to draw to
-properly draw to the screen.
+explicitly set.
 
 By writing only to the users Desktop or application folder that gets read
 by the Start Menu, there is no need for elevated permission and no writing
@@ -82,6 +80,33 @@ The arguments to the `make_shortcut` function are:
 Note that the Start Menu does not exist for MacOSX.
 
 The `executable` defaults to the version of Python executable used to make shortcut.
+
+
+## Note for running wxPython GUIs on macOS with Anaconda Python
+
+If your application uses wxPython and you are running with Anaconda Python on
+macOS, you may experience problems that your application does not start.  If
+you try to run your script from the command line, you may see the following
+error message:
+
+
+```
+~> python my_wxpython_app.py
+This program needs access to the screen. Please run with a
+Framework build of python, and only when you are logged in
+on the main display of your Mac.
+```
+
+
+If you do see that, it can be fixed and your script run properly by adding
+
+```
+import wx
+wx.PyApp.IsDisplayAvailable = lambda _: True
+```
+
+in your script before runnig your application,
+
 
 
 ##  `pyshortcut` command-line program

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=45", "wheel", "setuptools_scm>=6.2"]
+requires = ["setuptools>=45", "setuptools_scm>=6.2"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]

--- a/pyshortcuts/darwin.py
+++ b/pyshortcuts/darwin.py
@@ -36,25 +36,6 @@ def get_folders():
     return UserFolders(get_homedir(), get_desktop(), get_startmenu())
 
 
-def fix_anacondapy_pythonw(fname):
-    """fix shebang line for scripts using anaconda python
-    to use 'pythonw' instead of 'python'
-    """
-    # print(" fix anaconda py (%s) for %s" % (sys.prefix, script))
-    with open(fname, 'r') as fh:
-        try:
-            lines = fh.readlines()
-        except IOError:
-            lines = ['-']
-    firstline = lines[0][:-1].strip()
-    if firstline.startswith('#!') and 'python' in firstline:
-        firstline = '#!/usr/bin/env pythonw'
-        fh = open(fname, 'w')
-        fh.write('%s\n' % firstline)
-        fh.write("".join(lines[1:]))
-        fh.close()
-
-
 def make_shortcut(script, name=None, description=None, icon=None, working_dir=None,
                   folder=None, terminal=True, desktop=True,
                   startmenu=True, executable=None):
@@ -94,12 +75,7 @@ def make_shortcut(script, name=None, description=None, icon=None, working_dir=No
     prefix = os.path.normpath(sys.prefix)
     if executable is None:
         executable = sys.executable
-        # check for Anaconda on MacOSX
-        has_conda = os.path.exists(os.path.join(prefix, 'conda-meta'))
-        pyapp_exe = "{:s}/python.app/Contents/MacOS/python".format(prefix)
-        if has_conda and os.path.exists(pyapp_exe):
-            executable = pyapp_exe
-            fix_anacondapy_pythonw(scut.full_script)
+
     executable = os.path.normpath(executable)
 
     if not os.path.exists(scut.desktop_dir):
@@ -139,11 +115,9 @@ def make_shortcut(script, name=None, description=None, icon=None, working_dir=No
 """
 
     text = ['#!/bin/bash',
-            "## Make sure to set PYTHONEXECUTABLE to Python that created this script",
-            "export PYTHONEXECUTABLE={prefix:s}/bin/python",
             "export EXE={exe:s}",
             "export SCRIPT={script:s}",
-            "export ARGS='{args:s}'", " "]
+            "export ARGS='{args:s}'"]
 
     if scut.working_dir not in (None, ''):
         text.append("cd {workdir:s}")

--- a/pyshortcuts/wxgui.py
+++ b/pyshortcuts/wxgui.py
@@ -28,6 +28,8 @@ FONTSIZE = 11
 if platform == 'linux':
     FONTSIZE = 10
 
+if platform.startswith('darwin'):
+    wx.PyApp.IsDisplayAvailable = lambda _: True
 
 class ShortcutFrame(wx.Frame):
     def __init__(self):

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ author_email = matt.newville@gmail.com
 url = https://github.com/newville/pyshortcuts
 license = MIT License
 platforms = any
-version  = 1.8.1
+version  = 1.9.0
 classifiers =
     Development Status :: 5 - Production/Stable
     Intended Audience :: End Users/Desktop
@@ -36,10 +36,10 @@ classifiers =
     Operating System :: POSIX
     Programming Language :: Python
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Programming Language :: Python :: Implementation :: PyPy
 keywords = desktop shortcuts
 project_urls =
@@ -50,7 +50,7 @@ project_urls =
 [options]
 packages = find:
 include_package_data = True
-python_requires = >=3.6
+python_requires = >=3.8
 setup_requires = setuptools_scm
 install_requires =
     pywin32 ; platform_system== "Windows"


### PR DESCRIPTION
this removes the use of ``python.app`` on macOS, and updates the documentation to describe how to avoid wx vs. Anaconda Python errors on macOS.